### PR TITLE
Fix Bug AI only building Harpies from air

### DIFF
--- a/pa/ai/factory_builds/bugs/factory_air_builds.json
+++ b/pa/ai/factory_builds/bugs/factory_air_builds.json
@@ -174,7 +174,7 @@
       "to_build": "Harpy",
       "instance_count": -1,
       "max_num_assisters": 10,
-      "priority": 199,
+      "priority": 97,
       "builders": ["BasicAirHive"],
       "build_conditions": [
         [


### PR DESCRIPTION
Due to priority issue on build, the bug AI currently only builds Harpies from its air factories until it has at least 20 of them alive.