### PR TITLE
Update AI for Bug Naval Fabbers

### DIFF
--- a/pa/ai/fabber_builds/bugs/fabber_naval_builds.json
+++ b/pa/ai/fabber_builds/bugs/fabber_naval_builds.json
@@ -224,6 +224,102 @@
           "value": 50
         }
       }
+    },
+    {
+      "name": "Bugs - Advanced Naval Factory",
+      "to_build": "AdvancedNavalHive",
+      "instance_count": 1,
+      "shared_instance_count": "AdvancedFactory",
+      "priority": 477,
+      "min_num_assisters": 3,
+      "max_num_assisters": 5,
+      "builders": ["BugBasicNavalFabber", "BugAdvancedNavalFabber"],
+      "build_conditions": [
+        [
+          { "test_type": "HaveEcoForAdvanced", "boolean": true },
+          { "test_type": "NeedAdvancedNavalFactory", "boolean": true },
+          {
+            "test_type": "CanAffordPotentialDrain",
+            "string0": "AdvancedNavalHive"
+          },
+          {
+            "test_type": "CanFindPlaceToBuild",
+            "string0": "AdvancedNavalHive"
+          }
+        ],
+        [
+          { "test_type": "UnableToExpand", "boolean": true },
+          { "test_type": "NeedAdvancedNavalFactory", "boolean": true },
+          {
+            "test_type": "UnitCountOnPlanet",
+            "unit_type_string0": "(Factory & Advanced) - NukeDefense - Nuke - SelfDestruct",
+            "compare0": "<",
+            "value0": 1
+          },
+          {
+            "test_type": "CanFindPlaceToBuild",
+            "string0": "AdvancedNavalHive"
+          }
+        ]
+      ],
+      "placement_rules": {
+        "buffer": 3,
+        "threat": {
+          "influence_type": "AntiSurface",
+          "compare_type": "<",
+          "radius": 10,
+          "value": 50
+        }
+      }
+    },
+    {
+      "name": "Bugs - Advanced Naval Factory - Wasting",
+      "to_build": "AdvancedNavalHive",
+      "instance_count": 1,
+      "shared_instance_count": "AdvancedFactory",
+      "priority": 525,
+      "min_num_assisters": 3,
+      "max_num_assisters": 5,
+      "builders": ["BugBasicNavalFabber", "BugAdvancedNavalFabber"],
+      "build_conditions": [
+        [
+          { "test_type": "HaveEcoForAdvanced", "boolean": true },
+          {
+            "test_type": "HasPersonalityTag",
+            "string0": "PreventsWaste",
+            "boolean": true
+          },
+          {
+            "test_type": "CurrentMetalEfficiency",
+            "compare0": ">",
+            "value0": 1
+          },
+          { "test_type": "MetalStorageFrac", "compare0": ">", "value0": 0.05 },
+          {
+            "test_type": "CurrentEnergyEfficiency",
+            "compare0": ">=",
+            "value0": 1
+          },
+          { "test_type": "NeedAdvancedNavalFactory", "boolean": false },
+          {
+            "test_type": "CanAffordPotentialDrain",
+            "string0": "AdvancedNavalHive"
+          },
+          {
+            "test_type": "CanFindPlaceToBuild",
+            "string0": "AdvancedNavalHive"
+          }
+        ]
+      ],
+      "placement_rules": {
+        "buffer": 3,
+        "threat": {
+          "influence_type": "AntiSurface",
+          "compare_type": "<",
+          "radius": 10,
+          "value": 50
+        }
+      }
     }
   ]
 }

--- a/pa/ai/fabber_builds/bugs/fabber_titan_builds_x1.json
+++ b/pa/ai/fabber_builds/bugs/fabber_titan_builds_x1.json
@@ -211,9 +211,7 @@
       "max_num_assisters": 15,
       "shared_instance_count": "Titan",
       "priority": 480,
-      "builders": [
-        "AnyAdvancedFabber"
-      ],
+      "builders": ["AnyAdvancedFabber"],
       "build_conditions": [
         [
           {

--- a/pa/ai/factory_builds/bugs/factory_naval_builds.json
+++ b/pa/ai/factory_builds/bugs/factory_naval_builds.json
@@ -2,7 +2,7 @@
   "build_list": [
     {
       "name": "Bugs - Basic Naval Fabber",
-      "to_build": "BugBugBasicNavalFabber",
+      "to_build": "BugBasicNavalFabber",
       "instance_count": 1,
       "max_num_assisters": 10,
       "priority": 100,
@@ -24,7 +24,7 @@
           },
           {
             "test_type": "CanAffordPotentialDrain",
-            "string0": "BugBugBasicNavalFabber"
+            "string0": "BugBasicNavalFabber"
           }
         ]
       ]

--- a/pa/ai/factory_builds/bugs/factory_naval_builds.json
+++ b/pa/ai/factory_builds/bugs/factory_naval_builds.json
@@ -110,6 +110,117 @@
           }
         ]
       ]
+    },
+    {
+      "name": "Bugs - Advanced Naval Fabber",
+      "to_build": "BugsAdvancedNavalFabber",
+      "instance_count": 1,
+      "max_num_assisters": 15,
+      "priority": 200,
+      "builders": ["AdvancedNavalHive"],
+      "build_conditions": [
+        [
+          {
+            "test_type": "BaseThreatened",
+            "boolean": false
+          },
+          {
+            "test_type": "CanAffordBuildDemand"
+          },
+          {
+            "test_type": "UnitCountOnPlanet",
+            "unit_type_string0": "Naval & Fabber & Advanced",
+            "compare0": "<",
+            "value0": 2
+          },
+          {
+            "test_type": "CanAffordPotentialDrain",
+            "string0": "AdvancedNavalFabber"
+          }
+        ]
+      ]
+    },
+    {
+      "name": "Bugs - Battleship",
+      "to_build": "Battleship",
+      "instance_count": -1,
+      "max_num_assisters": 15,
+      "priority": 199,
+      "builders": ["AdvancedNavalHive"],
+      "build_conditions": [
+        [
+          {
+            "test_type": "AloneOnPlanet",
+            "boolean": false
+          },
+          {
+            "test_type": "CanDeployNavalFromBase",
+            "boolean": true
+          },
+          {
+            "test_type": "CanAffordBuildDemand"
+          }
+        ]
+      ]
+    },
+    {
+      "name": "Bugs - MissleShip",
+      "to_build": "MissleShip",
+      "instance_count": -1,
+      "max_num_assisters": 15,
+      "priority": 199,
+      "builders": ["AdvancedNavalHive"],
+      "build_conditions": [
+        [
+          {
+            "test_type": "AloneOnPlanet",
+            "boolean": false
+          },
+          {
+            "test_type": "CanDeployNavalFromBase",
+            "boolean": true
+          },
+          {
+            "test_type": "CanAffordBuildDemand"
+          }
+        ]
+      ]
+    },
+    {
+      "name": "Bugs - Missile Sub",
+      "to_build": "MissileSub",
+      "instance_count": -1,
+      "max_num_assisters": 15,
+      "priority": 199,
+      "builders": ["AdvancedNavalHive"],
+      "build_conditions": [
+        [
+          {
+            "test_type": "AloneOnPlanet",
+            "boolean": false
+          },
+          {
+            "test_type": "CanDeployNavalFromBase",
+            "boolean": true
+          },
+          {
+            "test_type": "PlanetThreat",
+            "string0": "Naval",
+            "compare0": ">",
+            "value0": 0
+          },
+          {
+            "test_type": "UnitRatioOnPlanet",
+            "unit_type_string0": "Mobile & Naval & Sub",
+            "unit_type_string1": "Mobile & Naval - Fabber",
+            "compare0": "<",
+            "value0": 0.25
+          },
+          {
+            "test_type": "CanAffordBuildDemand"
+          }
+        ]
+      ]
     }
   ]
 }

--- a/pa/ai/factory_builds/bugs/factory_naval_builds.json
+++ b/pa/ai/factory_builds/bugs/factory_naval_builds.json
@@ -113,7 +113,7 @@
     },
     {
       "name": "Bugs - Advanced Naval Fabber",
-      "to_build": "BugsAdvancedNavalFabber",
+      "to_build": "BugAdvancedNavalFabber",
       "instance_count": 1,
       "max_num_assisters": 15,
       "priority": 200,

--- a/pa/ai/factory_builds/bugs/factory_naval_builds.json
+++ b/pa/ai/factory_builds/bugs/factory_naval_builds.json
@@ -2,7 +2,7 @@
   "build_list": [
     {
       "name": "Bugs - Basic Naval Fabber",
-      "to_build": "BasicNavalFabber",
+      "to_build": "BugBugBasicNavalFabber",
       "instance_count": 1,
       "max_num_assisters": 10,
       "priority": 100,
@@ -24,7 +24,7 @@
           },
           {
             "test_type": "CanAffordPotentialDrain",
-            "string0": "BasicNavalFabber"
+            "string0": "BugBugBasicNavalFabber"
           }
         ]
       ]

--- a/pa/ai/factory_builds/bugs/factory_naval_builds_x1.json
+++ b/pa/ai/factory_builds/bugs/factory_naval_builds_x1.json
@@ -28,6 +28,48 @@
           }
         ]
       ]
+    },
+    {
+      "name": "Bugs - Hover Ship",
+      "to_build": "HoverShip",
+      "instance_count": -1,
+      "max_num_assisters": 15,
+      "priority": 199,
+      "builders": ["AdvancedNavalHive"],
+      "build_conditions": [
+        [
+          {
+            "test_type": "AloneOnPlanet",
+            "boolean": false
+          },
+          {
+            "test_type": "CanAffordBuildDemand"
+          }
+        ]
+      ]
+    },
+    {
+      "name": "Bugs - Drone Carrier",
+      "to_build": "DroneCarrier",
+      "instance_count": -1,
+      "max_num_assisters": 15,
+      "priority": 199,
+      "builders": ["AdvancedNavalHive"],
+      "build_conditions": [
+        [
+          {
+            "test_type": "AloneOnPlanet",
+            "boolean": false
+          },
+          {
+            "test_type": "CanDeployNavalFromBase",
+            "boolean": true
+          },
+          {
+            "test_type": "CanAffordBuildDemand"
+          }
+        ]
+      ]
     }
   ]
 }

--- a/pa/ai/unit_maps/bugs.json
+++ b/pa/ai/unit_maps/bugs.json
@@ -114,6 +114,9 @@
     "BasicNavalHive": {
       "spec_id": "/pa/units/structure/basic_naval_hive/basic_naval_hive.json"
     },
+    "AdvancedNavalHive": {
+      "spec_id": "/pa/units/structure/advanced_naval_hive/advanced_naval_hive.json"
+    },
     "BugTeleporter": {
       "spec_id": "/pa/units/structure/bug_teleporter/bug_teleporter.json"
     },

--- a/pa/ai/unit_maps/bugs.json
+++ b/pa/ai/unit_maps/bugs.json
@@ -324,10 +324,10 @@
     "BugOrbitalLaserUnlock": {
       "spec_id": "/pa/units/research/unlocks/bug_orbital_laser_unlock/research_bug_orbital_laser.json"
     },
-    "BugBugBasicNavalFabber": {
+    "BugBasicNavalFabber": {
       "spec_id": "/pa/units/sea/bug_ship_fab/bug_ship_fab.json"
     },
-    "BugBugAdvancedNavalFabber": {
+    "BugAdvancedNavalFabber": {
       "spec_id": "/pa/units/sea/bug_ship_fab_adv/bug_ship_fab_adv.json"
     }
   }


### PR DESCRIPTION
Adds support for bug naval fabbers and the advanced naval hive. This also stops the spamming of errors in the log by the AI attempting to build an MLA fabber from the bug basic naval hive, which no longer is possible.